### PR TITLE
Offline Installation Requirements

### DIFF
--- a/SigProfilerMatrixGenerator/install.py
+++ b/SigProfilerMatrixGenerator/install.py
@@ -382,7 +382,7 @@ def install (genome, custom=False, rsync=False, bash=True, ftp=True, fastaPath=N
 	ref_dir = os.path.dirname(os.path.abspath(__file__))
 	os.chdir(ref_dir)
 
-	if not custom:
+	if not custom and offline_files_path is None:
 		wget_install = shutil.which("wget") is not None
 		rsync_install = shutil.which("rsync") is not None
 		if not wget_install and not rsync_install:

--- a/SigProfilerMatrixGenerator/scripts/convert_input_to_simple_files.py
+++ b/SigProfilerMatrixGenerator/scripts/convert_input_to_simple_files.py
@@ -570,7 +570,6 @@ def convertTxt (project, vcf_path, genome, output_path, ncbi_chrom, log_file):
 					sample = line[1]
 					if sample not in samples:
 						samples.append(sample)
-					genome = line[3]
 					chrom = line[5]
 					if len(chrom) > 2:
 						chrom = chrom[3:]
@@ -1173,7 +1172,6 @@ def convertMAF (project, vcf_path, genome, output_path, ncbi_chrom, log_file):
 					line = lines.strip().split("\t")
 					if len(line) == 0:
 						continue
-					genome = line[3]
 					chrom = line[4]
 					if len(chrom) > 2:
 						chrom = chrom[3:]
@@ -1786,7 +1784,6 @@ def convertICGC (project, vcf_path, genome, output_path, ncbi_chrom, log_file):
 						chrom = "MT"
 					start = line[9]
 					end = line[10]
-					genome = line[12]
 					ref = line[15]
 					mut = line[16]
 					if ref == '-':
@@ -2332,7 +2329,3 @@ def convertICGC (project, vcf_path, genome, output_path, ncbi_chrom, log_file):
 		#out_indel.close()
 	out.close()
 	return(snv, indel, skipped_count, samples)
-
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme():
 	# with open('README.rst') as f:
 	# 	return(f.read())
 
-VERSION = '1.1.25'
+VERSION = '1.1.28'
 
 def write_version_py(filename='SigProfilerMatrixGenerator/version.py'):
 	# Copied from numpy setup.py


### PR DESCRIPTION
Users installing files offline were receiving error that they did not have wget nor rsync installed. These are not requirements for offline installation so the code has been updated to not require wget and rsync when user is using offline_files_path.