### PR TITLE
Custom Genome Installation Errors

### DIFF
--- a/SigProfilerMatrixGenerator/install.py
+++ b/SigProfilerMatrixGenerator/install.py
@@ -320,10 +320,13 @@ def install_chromosomes_tsb (genomes, ref_dir, custom):
 			
 		print("The transcriptional reference data for " + genome + " has been saved.")
 
-def install_chromosomes_tsb_BED (genomes, ref_dir):
+def install_chromosomes_tsb_BED (genomes, ref_dir, custom):
 	for genome in genomes:
 		if not os.path.exists(ref_dir + "chromosomes/tsb_BED/" + genome + "/") or len(os.listdir(ref_dir + "chromosomes/tsb_BED/" + genome + "/")) < 19:
-			os.system("python scripts/save_chrom_tsb_separate.py -g " + genome)
+			is_custom = False
+			if custom:
+				is_custom = True
+			os.system("python scripts/save_chrom_tsb_separate.py -g " + genome + " -c " + str(is_custom))
 			print("The TSB BED files for " + genome + " have been saved.")
 
 def benchmark (genome, ref_dir):
@@ -433,7 +436,8 @@ def install (genome, custom=False, rsync=False, bash=True, ftp=True, fastaPath=N
 		if os.path.exists(ref_dir + "/references/chromosomes/exome/" + genome + "/"):
 			shutil.rmtree(ref_dir + "/references/chromosomes/exome/" + genome + "/")
 		os.makedirs(ref_dir + "/references/chromosomes/exome/" +  genome + "/")
-		shutil.copy(exomePath,ref_dir + "/references/chromosomes/exome/" +  genome + "/")
+		if exomePath is not None:
+			shutil.copy(exomePath,ref_dir + "/references/chromosomes/exome/" +  genome + "/")
 
 
 	if ftp:
@@ -538,7 +542,7 @@ def install (genome, custom=False, rsync=False, bash=True, ftp=True, fastaPath=N
 		install_chromosomes_tsb (genomes, ref_dir, custom)
 
 		if custom:
-			install_chromosomes_tsb_BED (genomes, ref_dir)
+			install_chromosomes_tsb_BED (genomes, ref_dir, custom)
 
 	if os.path.exists("BRCA_example/"):
 		shutil.copy("BRCA_example/", "references/vcf_files/")

--- a/SigProfilerMatrixGenerator/scripts/save_chrom_tsb_separate.py
+++ b/SigProfilerMatrixGenerator/scripts/save_chrom_tsb_separate.py
@@ -10,7 +10,7 @@ import os
 import argparse
 import re
 
-def save_chrom_tsb_separate (genome, ref_dir):
+def save_chrom_tsb_separate (genome, ref_dir, custom):
 	'''
 	Saves the transcriptional strand bias information for a given genome 
 	into a BED file.
@@ -44,6 +44,9 @@ def save_chrom_tsb_separate (genome, ref_dir):
 			   16:['N','N'], 17:['T','N'], 18:['U','N'], 19:['B','N']}
 	tsb_ref_original = {'N':0, 'T':1, 'U':2, 'B':3}
 
+	if custom:
+		tsb_list = [f for f in os.listdir(chromosome_path) if not f.startswith('.')]
+		chromosomes = sorted([tmp_chrom.replace(".txt", "") for tmp_chrom in tsb_list])
 
 	# Truncates the chromosome variable if a mouse genome is provided
 	if genome == 'mm10' or genome == 'mm9':
@@ -86,13 +89,15 @@ def save_chrom_tsb_separate (genome, ref_dir):
 def main ():
 	parser = argparse.ArgumentParser(description="Provide the necessary arguments to install the reference files.")
 	parser.add_argument("-g", "--genome", nargs='?', help="Optional parameter instructs script to install the custom genome.")
+	parser.add_argument("-c", "--custom", help="custom genome?. (True or False)", default=False)
 	args = parser.parse_args()
 	genome = args.genome
+	custom = bool(args.custom)
 
 	current_dir = os.getcwd()
 	ref_dir = re.sub('\/scripts$', '', current_dir)
 
-	save_chrom_tsb_separate(genome, ref_dir)
+	save_chrom_tsb_separate(genome, ref_dir, custom)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Two issues identified in this pull request:

1. If the exome path is not set, then the following code causes the program to error because the following was always run: shutil.copy(exomePath,ref_dir + "/references/chromosomes/exome/" +  genome + "/“)
		- solution: Add a check to verify that exomePath is not None before running shutil.copy
2. For custom installing a genome, the function install_chromosomes_tsb_BED calls the script save_chrom_tsb_separate.py. No information is provided about what chromosomes the genome has and by default chromosomes is set as:
	chromosomes = ['X', 'Y', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12','13', '14', '15', '16', '17', '18', '19', '20', '21', '22’]
		- solution: indicate to save_chrom_tsb_seperate.py that a custom genome is being installed. Use files found in /references/chromosomes/tsb/custom_genome_name/ to create a list of the chromosomes that will be used for creating the tsb_BED files. 