### PR TITLE
Copy number rounding and PURPLE file type support for `generateCNVMatrix`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ install:
   - pip install --force-reinstall "setuptools<60.0"
   - pip install .
 
-script: python3 test.py
-
+script: python3 -m unittest test

--- a/SigProfilerMatrixGenerator/references/CNV/example.purple.tsv
+++ b/SigProfilerMatrixGenerator/references/CNV/example.purple.tsv
@@ -1,2 +1,3 @@
 chromosome	start	end	copyNumber	bafCount	observedBAF	baf	segmentStartSupport	segmentEndSupport	method	depthWindowCount	gcContent	minStart	maxStart	minorAlleleCopyNumber	majorAlleleCopyNumber
 1	1	87337011	2.8189	4464	0.7094	0.7124	TELOMERE	BND	BAF_WEIGHTED	77277	0.4351	1	1	0.8165	2.0076
+3	60627611	60718930	1.2627	8	0.5278	0.5369	DUP	DUP	BAF_WEIGHTED	82	0.3719	60627611	60627611	0.5848	0.6779

--- a/SigProfilerMatrixGenerator/references/CNV/example.purple.tsv
+++ b/SigProfilerMatrixGenerator/references/CNV/example.purple.tsv
@@ -1,0 +1,2 @@
+chromosome	start	end	copyNumber	bafCount	observedBAF	baf	segmentStartSupport	segmentEndSupport	method	depthWindowCount	gcContent	minStart	maxStart	minorAlleleCopyNumber	majorAlleleCopyNumber
+1	1	87337011	2.8189	4464	0.7094	0.7124	TELOMERE	BND	BAF_WEIGHTED	77277	0.4351	1	1	0.8165	2.0076

--- a/test.py
+++ b/test.py
@@ -54,5 +54,7 @@ class TestPurpleCnvMatrix(TestCase):
             sample_name = "example.purple"
             # Verify that the right column is 1.
             self.assertEqual(df_purple.loc[sample_name, "3-4:het:>40Mb"], 1)
+            self.assertEqual(df_purple.loc[sample_name, "2:het:0-100kb"], 1)
+
             # Check that the remaining columns are zero.
-            self.assertEqual(df_purple.sum(axis=1)[sample_name], 1)
+            self.assertEqual(df_purple.sum(axis=1)[sample_name], 2)

--- a/test.py
+++ b/test.py
@@ -1,2 +1,50 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from pandas import read_csv
+from pandas.testing import assert_frame_equal
+
 from SigProfilerMatrixGenerator import install as genInstall
-from SigProfilerMatrixGenerator.scripts import SigProfilerMatrixGeneratorFunc as matGen
+from SigProfilerMatrixGenerator.scripts import (
+    SigProfilerMatrixGeneratorFunc as matGen,
+    CNVMatrixGenerator as scna,
+)
+
+
+REFERENCE_CNV = Path().resolve() / "SigProfilerMatrixGenerator" / "references" / "CNV"
+
+
+class TestPurpleCnvMatrix(TestCase):
+    def test_purple_cnv_file(self):
+        """Test parse a CNV file in PURPLE format.
+
+        We have transformed the first records in
+        "all.breast.ascat.summary.sample.tsv" from ASCAT format to PURPLE
+        format. This unit test verifies, irrespective of the data format, the
+        same matrix is generated.
+        """
+        cnv_in_ascat = REFERENCE_CNV / "all.breast.ascat.summary.sample.tsv"
+        cnv_in_purple = REFERENCE_CNV / "example.purple.sample.tsv"
+        with TemporaryDirectory() as tmpdir:
+            scna.generateCNVMatrix(
+                file_type="ASCAT",
+                input_file=cnv_in_ascat,
+                project="ascat",
+                output_path=tmpdir,
+            )
+            scna.generateCNVMatrix(
+                file_type="PURPLE",
+                input_file=cnv_in_purple,
+                project="purple",
+                output_path=tmpdir,
+            )
+
+            ascat_matrix_name = tmpdir + "ascat/ASCAT.CNV.matrix.tsv"
+            df_ascat = read_csv(ascat_matrix_name, sep="\t", index_col=0)
+
+            purple_matrix_name = tmpdir + "purple/PURPLE.CNV.matrix.tsv"
+            df_purple = read_csv(purple_matrix_name, sep="\t", index_col=0)
+
+            # Verify that the first two segments are identical.
+            assert_frame_equal(df_ascat.iloc[:2], df_purple.iloc[:2])


### PR DESCRIPTION
This pull request relates to issue #80 and contributes the following to `generateCNVMatrix` in `CNVMatrixGenerator`:
- Rounding of floating point copy numbers to integers.
- Support for the PURPLE copy number file-type format. I've added a simple example file (`SigProfilerMatrixGenerator/references/CNV/example.purple.tsv`) based on the slightly outdated [PURPLE docs on Github](https://github.com/hartwigmedical/hmftools/blob/master/purple/README.md#output).

In addition, I've written two unit tests in `test.py` to test the new contribution (and updated travis.yml accordingly).
Let me know if this pull request needs any more work.

Hylke