### PR TITLE
Improve how reference directory is determined

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,22 @@ UNIT TESTS
 
 unit tests can be run with
 
-```
+```bash
 python setup.py sdist
-python -m unittest discover tests
+pip install .[tests]
+pytest tests
 ```
 
+END-TO-END tests
+
+An integration test can be run with the following commands:
+
+```bash
+wget ftp://alexandrovlab-ftp.ucsd.edu/pub/tools/SigProfilerMatrixGenerator/GRCh37.tar.gz -P ./src/
+pip install .
+python3 install_genome.py src/ GRCh37
+python3 test.py -t GRCh37
+```
 
 **CITATION**
 

--- a/SigProfilerMatrixGenerator/install.py
+++ b/SigProfilerMatrixGenerator/install.py
@@ -699,9 +699,9 @@ def install_chromosomes_tsb_BED(genomes, ref_dir, custom):
 
 
 def benchmark(genome, ref_dir):
-    # current_dir = os.path.realpath(__file__)
-    # ref_dir = re.sub('\/install.py$', '', current_dir)
-    ref_dir = os.path.dirname(os.path.abspath(__file__))
+    # NOTE: ref_dir is overridden, so its value is currently ignored.
+    reference_dir = ref_install.reference_dir()
+    ref_dir = str(reference_dir.path)
     vcf_path = ref_dir + "/references/vcf_files/" + genome + "_bench/"
 
     start_time = time.time()
@@ -995,7 +995,6 @@ def install(
     else:
         print("Beginning installation. This may take up to 20 minutes to complete.")
         first_path = os.getcwd()
-        ref_dir = os.path.dirname(os.path.abspath(__file__))
         os.chdir(ref_dir)
 
         print(

--- a/SigProfilerMatrixGenerator/scripts/SigProfilerMatrixGenerator.py
+++ b/SigProfilerMatrixGenerator/scripts/SigProfilerMatrixGenerator.py
@@ -24,6 +24,8 @@ import sigProfilerPlotting as sigPlt
 import statsmodels.stats.multitest as sm
 from scipy import stats
 
+from SigProfilerMatrixGenerator.scripts import ref_install
+
 
 ################# Functions and references ###############################################
 def df2csv(df, fname, formats=[], sep="\t"):
@@ -93,9 +95,8 @@ def reference_paths(genome):
     Returns:
             chrom_path  -> path to the reference genome's chromosome files
     """
-    # current_dir = os.path.realpath(__file__)
-    # ref_dir = re.sub('\/scripts/SigProfilerMatrixGenerator.py$', '', current_dir)
-    ref_dir, tail = os.path.split(os.path.dirname(os.path.abspath(__file__)))
+    reference_dir = ref_install.reference_dir()
+    ref_dir = str(reference_dir.path)
     chrom_path = ref_dir + "/references/chromosomes/tsb/" + genome + "/"
 
     return (chrom_path, ref_dir)
@@ -2037,7 +2038,8 @@ def exome_check(
 
     initial = True
     udpate_chrom = False
-    ref_dir, tail = os.path.split(os.path.dirname(os.path.abspath(__file__)))
+    reference_dir = ref_install.reference_dir()
+    ref_dir = str(reference_dir.path)
 
     exome_file = (
         ref_dir
@@ -2407,7 +2409,8 @@ def panel_check(
     # Instantiates the relevant variables/data structures
     base_cushion = cushion
     # samples = []
-    ref_dir = os.path.dirname(os.path.abspath(__file__))
+    reference_dir = ref_install.reference_dir()
+    ref_dir = str(reference_dir.path)
 
     romanNumeralConversion = {
         "I": 1,
@@ -2790,7 +2793,8 @@ def matrix_generator(
     """
 
     # Prepares all of the required data structures and files
-    ref_dir = os.path.dirname(os.path.abspath(__file__))
+    reference_dir = ref_install.reference_dir()
+    ref_dir = str(reference_dir.path)
 
     contexts = ["96", "384", "1536", "6", "24", "288", "4608", "18"]
     mut_count_all["6144"].index.name = "MutationType"
@@ -3360,9 +3364,8 @@ def matrix_generator_INDEL(
     """
 
     # Instantiates all of the required data structures and output files
-    # current_dir = os.getcwd()
-    # ref_dir = re.sub('\/scripts$', '', current_dir)
-    ref_dir = os.path.dirname(os.path.abspath(__file__))
+    reference_dir = ref_install.reference_dir()
+    ref_dir = str(reference_dir.path)
 
     bias_sort = {"T": 0, "U": 1, "N": 3, "B": 2, "Q": 4}
     col_sort = {"C": 0, "T": 1, "R": 2, "M": 3}
@@ -3731,7 +3734,9 @@ def matrix_generator_DINUC(
     if not os.path.exists(output_matrix_DINUC):
         os.mkdir(output_matrix_DINUC)
 
-    ref_dir = os.path.dirname(os.path.abspath(__file__))
+    reference_dir = ref_install.reference_dir()
+    ref_dir = str(reference_dir.path)
+
     file_prefix = project + ".DBS2976"
     if exome:
         output_file_matrix = output_matrix_DINUC + file_prefix + ".exome"

--- a/SigProfilerMatrixGenerator/scripts/SigProfilerMatrixGeneratorFunc.py
+++ b/SigProfilerMatrixGenerator/scripts/SigProfilerMatrixGeneratorFunc.py
@@ -29,6 +29,7 @@ from SigProfilerMatrixGenerator import install
 from SigProfilerMatrixGenerator.scripts import (
     convert_input_to_simple_files as convertIn,
 )
+from SigProfilerMatrixGenerator.scripts import ref_install
 
 from . import SigProfilerMatrixGenerator as matGen
 
@@ -1193,7 +1194,8 @@ def SigProfilerMatrixGeneratorFunc(
     contexts = ["6144"]
 
     # Organizes all of the reference directories for later reference:
-    ref_dir, tail = os.path.split(os.path.dirname(os.path.abspath(__file__)))
+    reference_dir = ref_install.reference_dir()
+    ref_dir = str(reference_dir.path)
     chrom_path = ref_dir + "/references/chromosomes/tsb/" + reference_genome + "/"
     if "havana" in reference_genome:
         reference_genome = reference_genome.split("_")[0]

--- a/SigProfilerMatrixGenerator/scripts/save_chrom_strings.py
+++ b/SigProfilerMatrixGenerator/scripts/save_chrom_strings.py
@@ -11,6 +11,8 @@ import os
 import re
 import sys
 
+from SigProfilerMatrixGenerator.scripts import ref_install
+
 
 def save_chrom_strings(genome, custom):
     """
@@ -29,7 +31,9 @@ def save_chrom_strings(genome, custom):
     """
 
     # Instantiates all of the relevant paths/creates them if not present
-    ref_dir, tail = os.path.split(os.path.dirname(os.path.abspath(__file__)))
+
+    reference_dir = ref_install.reference_dir()
+    ref_dir = str(reference_dir.path)
     chrom_fasta_path = ref_dir + "/references/chromosomes/fasta/" + genome + "/"
     chrom_string_path = ref_dir + "/references/chromosomes/chrom_string/" + genome + "/"
     chrom_fasta_files = os.listdir(chrom_fasta_path)

--- a/SigProfilerMatrixGenerator/scripts/save_tsb_192.py
+++ b/SigProfilerMatrixGenerator/scripts/save_tsb_192.py
@@ -12,6 +12,8 @@ import re
 import sys
 import time
 
+from SigProfilerMatrixGenerator.scripts import ref_install
+
 start_time = time.time()
 
 
@@ -457,9 +459,8 @@ def main():
     args = parser.parse_args()
     genome = args.genome
 
-    # script_dir = os.getcwd()
-    # ref_dir = re.sub('\/scripts$', '', script_dir)
-    ref_dir, tail = os.path.split(os.path.dirname(os.path.abspath(__file__)))
+    reference_dir = ref_install.reference_dir()
+    ref_dir = str(reference_dir.path)
 
     chromosome_string_path = (
         ref_dir + "/references/chromosomes/chrom_string/" + genome + "/"

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,11 @@ setup(
         "numpy>=1.18.5",
         "pandas>=0.23.4,<2.0.0",
     ],
+    extras_require={
+        "tests": [
+            "pytest",
+        ],
+    },
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
- Rather than determining the location of the reference directory relative to the calling `__file__`, refer to it using `ref_install.reference_dir()` instead. This way we can centralise and improve how this is done
- Add pytest to the requirements for running tests and update README instructions
- Add instructions on how to run end-to-end tests