### PR TITLE
Change how fasta and tsb folders are referred to

### DIFF
--- a/SigProfilerMatrixGenerator/install.py
+++ b/SigProfilerMatrixGenerator/install.py
@@ -336,11 +336,14 @@ def md5(fname):
     return hash_md5.hexdigest()
 
 
-def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
+def install_chromosomes(
+    genomes, reference_dir: ref_install.ReferenceDir, custom, rsync, bash
+):
+    ref_dir = str(reference_dir.path)
+    absolute_fasta_root_dir = str(reference_dir.get_fasta_root_dir())
     if custom:
         for genome in genomes:
-            os.system("gzip -d references/chromosomes/fasta/" + genome + "/*.gz")
-            chromosome_fasta_path = "references/chromosomes/fasta/" + genome + "/"
+            os.system("gzip -d " + absolute_fasta_root_dir + "/" + genome + "/*.gz")
             save_chrom_strings.save_chrom_strings(genome, custom)
             print(
                 "Chromosome string files for "
@@ -370,8 +373,11 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
             chromosome_string_path = (
                 "references/chromosomes/chrom_string/" + genome + "/"
             )
-            chromosome_fasta_path = "references/chromosomes/fasta/" + genome + "/"
+            absolute_fasta_path = absolute_fasta_root_dir + "/" + genome + "/"
 
+            # this `if` statement is strange. Usually the "chromosomes" folder is in
+            # ref_dir + "references", not directly in ref_dir, so I would expect
+            # the first clause to always be False, and so the if statement
             if (
                 os.path.exists(ref_dir + "chromosomes/tsb/" + genome)
                 and len(os.listdir(ref_dir + "chromosomes/tsb/" + genome))
@@ -389,13 +395,12 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                     + chromosome_string_path
                 )
                 if (
-                    os.path.exists(chromosome_fasta_path) == False
-                    or len(os.listdir(chromosome_fasta_path)) <= chrom_number
+                    os.path.exists(absolute_fasta_path) == False
+                    or len(os.listdir(absolute_fasta_path)) <= chrom_number
                 ):
                     print(
                         "[DEBUG] Chromosome fasta files found at: "
-                        + ref_dir
-                        + chromosome_fasta_path
+                        + absolute_fasta_path
                     )
                     print(
                         "Chromosomes are not currently saved as individual text files for "
@@ -403,21 +408,6 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                         + ". Downloading the files now..."
                     )
                     if not rsync:
-                        # os.system("rsync -av -m --include='*/' --include='*.dna.chromosome.*' --exclude='*' rsync://ftp.ensembl.org/ensembl/pub/grch37/update/fasta/homo_sapiens/dna/ " + chromosome_fasta_path + " 2>&1>> install.log")
-                        # try:
-                        #     p = subprocess.Popen("wget", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                        # except:
-                        #     proceed = input("You may not have wget or homebrew installed. Download those dependencies now?[Y/N]").upper()
-                        #     if proceed == 'Y':
-                        #         try:
-                        #             os.system("brew install wget")
-                        #         except:
-                        #             os.system('/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"')
-                        #             os.system("brew install wget")
-                        #     else:
-                        #         print("Installation has stopped. Please download the chromosome files before proceeding with the installation.")
-                        #         wget_flag = False
-                        #         sys.exit()
                         if wget_flag:
                             try:
                                 if genome == "GRCh37":
@@ -425,30 +415,29 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                                         os.system(
                                             "bash -c '"
                                             + 'wget -r -l1 -c -nc --no-parent -A "*.dna.chromosome.*" -nd -P '
-                                            + chromosome_fasta_path
+                                            + absolute_fasta_path
                                             + " ftp://ftp.ensembl.org/pub/grch37/current/fasta/homo_sapiens/dna/ 2>> install.log"
                                             + "'"
                                         )
                                     else:
                                         os.system(
                                             'wget -r -l1 -c -nc --no-parent -A "*.dna.chromosome.*" -nd -P '
-                                            + chromosome_fasta_path
+                                            + absolute_fasta_path
                                             + " ftp://ftp.ensembl.org/pub/grch37/current/fasta/homo_sapiens/dna/ 2>> install.log"
                                         )
-                                    # os.system("wget -r -l1 -c -nc --no-parent -A '*.dna.chromosome.*' -nd -P " + chromosome_fasta_path + " ftp://ftp.ensembl.org/pub/grch37/update/fasta/homo_sapiens/dna/ 2>> install.log")
                                 elif genome == "mm9":
                                     if bash:
                                         os.system(
                                             "bash -c '"
                                             + 'wget -r -l1 -c -nc --no-parent -A "*.dna.chromosome.*" -nd -P '
-                                            + chromosome_fasta_path
+                                            + absolute_fasta_path
                                             + " ftp://ftp.ensembl.org/pub/release-67/fasta/mus_musculus/dna/ 2>> install.log"
                                             + "'"
                                         )
                                     else:
                                         os.system(
                                             'wget -r -l1 -c -nc --no-parent -A "*.dna.chromosome.*" -nd -P '
-                                            + chromosome_fasta_path
+                                            + absolute_fasta_path
                                             + " ftp://ftp.ensembl.org/pub/release-67/fasta/mus_musculus/dna/ 2>> install.log"
                                         )
 
@@ -457,14 +446,14 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                                         os.system(
                                             "bash -c '"
                                             + 'wget -r -l1 -c -nc --no-parent -A "*.dna.chromosome.*" -nd -P '
-                                            + chromosome_fasta_path
+                                            + absolute_fasta_path
                                             + " ftp://ftp.ensembl.org/pub/release-96/fasta/rattus_norvegicus/dna/ 2>> install.log"
                                             + "'"
                                         )
                                     else:
                                         os.system(
                                             'wget -r -l1 -c -nc --no-parent -A "*.dna.chromosome.*" -nd -P '
-                                            + chromosome_fasta_path
+                                            + absolute_fasta_path
                                             + " ftp://ftp.ensembl.org/pub/release-96/fasta/rattus_norvegicus/dna/ 2>> install.log"
                                         )
                                 else:
@@ -472,7 +461,7 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                                         os.system(
                                             "bash -c '"
                                             + 'wget -r -l1 -c -nc --no-parent -A "*.dna.chromosome.*" -nd -P '
-                                            + chromosome_fasta_path
+                                            + absolute_fasta_path
                                             + " ftp://ftp.ensembl.org/pub/release-93/fasta/"
                                             + species
                                             + "/dna/ 2>> install.log"
@@ -481,7 +470,7 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                                     else:
                                         os.system(
                                             'wget -r -l1 -c -nc --no-parent -A "*.dna.chromosome.*" -nd -P '
-                                            + chromosome_fasta_path
+                                            + absolute_fasta_path
                                             + " ftp://ftp.ensembl.org/pub/release-93/fasta/"
                                             + species
                                             + "/dna/ 2>> install.log"
@@ -505,14 +494,14 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                                     os.system(
                                         "bash -c '"
                                         + "rsync -av -m --include='*/' --include='*.dna.chromosome.*' --exclude='*' rsync://ftp.ensembl.org/ensembl/pub/grch37/current/fasta/homo_sapiens/dna/ "
-                                        + chromosome_fasta_path
+                                        + absolute_fasta_path
                                         + " 2>&1>> install.log"
                                         + "'"
                                     )
                                 else:
                                     os.system(
                                         "rsync -av -m --include='*/' --include='*.dna.chromosome.*' --exclude='*' rsync://ftp.ensembl.org/ensembl/pub/grch37/current/fasta/homo_sapiens/dna/ "
-                                        + chromosome_fasta_path
+                                        + absolute_fasta_path
                                         + " 2>&1>> install.log"
                                     )
                             elif genome == "mm9":
@@ -520,14 +509,14 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                                     os.system(
                                         "bash -c '"
                                         + "rsync -av -m --include='*/' --include='*.dna.chromosome.*' --exclude='*' rsync://ftp.ensembl.org/ensembl/pub/release-67/fasta/mus_musculus/dna/ "
-                                        + chromosome_fasta_path
+                                        + absolute_fasta_path
                                         + " 2>&1>> install.log"
                                         + "'"
                                     )
                                 else:
                                     os.system(
                                         "rsync -av -m --include='*/' --include='*.dna.chromosome.*' --exclude='*' rsync://ftp.ensembl.org/ensembl/pub/release-67/fasta/mus_musculus/dna/ "
-                                        + chromosome_fasta_path
+                                        + absolute_fasta_path
                                         + " 2>&1>> install.log"
                                     )
                             elif genome == "rn6":
@@ -535,14 +524,14 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                                     os.system(
                                         "bash -c '"
                                         + "rsync -av -m --include='*/' --include='*.dna.chromosome.*' --exclude='*' rsync://ftp.ensembl.org/ensembl/pub/release-96/fasta/rattus_norvegicus/dna/ "
-                                        + chromosome_fasta_path
+                                        + absolute_fasta_path
                                         + " 2>> install.log"
                                         + "'"
                                     )
                                 else:
                                     os.system(
                                         "rsync -av -m --include='*/' --include='*.dna.chromosome.*' --exclude='*' rsync://ftp.ensembl.org/ensembl/pub/release-96/fasta/rattus_norvegicus/dna/ "
-                                        + chromosome_fasta_path
+                                        + absolute_fasta_path
                                         + " 2>> install.log"
                                     )
                             else:
@@ -552,7 +541,7 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                                         + "rsync -av -m --include='*/' --include='*.dna.chromosome.*' --exclude='*' rsync://ftp.ensembl.org/ensembl/pub/release-93/fasta/"
                                         + species
                                         + "/dna/ "
-                                        + chromosome_fasta_path
+                                        + absolute_fasta_path
                                         + " 2>&1>> install.log"
                                         + "'"
                                     )
@@ -561,7 +550,7 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                                         "rsync -av -m --include='*/' --include='*.dna.chromosome.*' --exclude='*' rsync://ftp.ensembl.org/ensembl/pub/release-93/fasta/"
                                         + species
                                         + "/dna/ "
-                                        + chromosome_fasta_path
+                                        + absolute_fasta_path
                                         + " 2>&1>> install.log"
                                     )
 
@@ -587,7 +576,7 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                     + genome
                     + " have been created. Continuing with installation."
                 )
-                shutil.rmtree(chromosome_fasta_path)
+                shutil.rmtree(absolute_fasta_path)
 
             else:
                 print(
@@ -597,7 +586,8 @@ def install_chromosomes(genomes, ref_dir, custom, rsync, bash):
                 )
 
 
-def install_chromosomes_tsb(genomes, ref_dir, custom):
+def install_chromosomes_tsb(genomes, reference_dir: ref_install.ReferenceDir, custom):
+    ref_dir = str(reference_dir.path)
     for genome in genomes:
         chrom_number = None
         if genome == "GRCh37" or genome == "GRCh38":
@@ -618,9 +608,9 @@ def install_chromosomes_tsb(genomes, ref_dir, custom):
                 ]
             )
 
-        chromosome_TSB_path = "references/chromosomes/tsb/" + genome + "/"
+        chromosome_TSB_path = str(reference_dir.get_tsb_dir() / genome) + "/"
         transcript_files = "references/chromosomes/transcripts/" + genome + "/"
-        print("[DEBUG] Chromosome tsb files found at: " + ref_dir + chromosome_TSB_path)
+        print("[DEBUG] Chromosome tsb files found at: " + chromosome_TSB_path)
 
         if (
             os.path.exists(transcript_files) == False
@@ -649,7 +639,7 @@ def install_chromosomes_tsb(genomes, ref_dir, custom):
             transcript_path = (
                 ref_dir + "/references/chromosomes/transcripts/" + genome + "/"
             )
-            output_path = ref_dir + "/references/chromosomes/tsb/" + genome + "/"
+            output_path = str(reference_dir.get_tsb_dir() / genome) + "/"
             if os.path.exists(output_path) == False:
                 os.makedirs(output_path)
 
@@ -687,8 +677,14 @@ def install_chromosomes_tsb(genomes, ref_dir, custom):
         print("The transcriptional reference data for " + genome + " has been saved.")
 
 
-def install_chromosomes_tsb_BED(genomes, ref_dir, custom):
+def install_chromosomes_tsb_BED(
+    genomes, reference_dir: ref_install.ReferenceDir, custom
+):
+    ref_dir = str(reference_dir.path)
     for genome in genomes:
+        # this `if` statement is strange. Usually the "chromosomes" folder is in
+        # ref_dir + "references", not directly in ref_dir, so I would expect
+        # the first clause to always be True
         if (
             not os.path.exists(ref_dir + "chromosomes/tsb_BED/" + genome + "/")
             or len(os.listdir(ref_dir + "chromosomes/tsb_BED/" + genome + "/")) < 19
@@ -798,7 +794,7 @@ def install(
 
     chrom_string_dir = ref_dir + "/references/chromosomes/chrom_string/"
     chrom_fasta_dir = ref_dir + "/references/chromosomes/fasta/"
-    chrom_tsb_dir = ref_dir + "/references/chromosomes/tsb/"
+    chrom_tsb_dir = str(reference_dir.get_tsb_dir())
     matrix_dir = ref_dir + "/references/matrix/"
     vcf_dir = ref_dir + "/references/vcf_files/"
     bed_dir = ref_dir + "/references/vcf_files/BED/"
@@ -849,7 +845,7 @@ def install(
             )
 
     if ftp:
-        chromosome_fasta_path = ref_dir + "/references/chromosomes/tsb/"
+        chromosome_fasta_path = str(reference_dir.get_tsb_dir())
         print("Beginning installation. This may take up to 40 minutes to complete.")
         if not rsync:
             try:
@@ -892,14 +888,11 @@ def install(
                     )
                 os.system(
                     "tar -xzf "
-                    + ref_dir
-                    + "/references/chromosomes/tsb/"
-                    + genome
+                    + str(reference_dir.get_tsb_dir() / genome)
                     + ".tar.gz -C "
-                    + ref_dir
-                    + "/references/chromosomes/tsb/"
+                    + str(reference_dir.get_tsb_dir())
                 )
-                os.remove(ref_dir + "/references/chromosomes/tsb/" + genome + ".tar.gz")
+                os.remove(str(reference_dir.get_tsb_dir() / genome + ".tar.gz"))
             except:
                 print("The ensembl ftp site is not currently responding.")
                 sys.exit()
@@ -944,13 +937,12 @@ def install(
         cur_dir = os.getcwd()
         os.chdir(first_path)
         shutil.unpack_archive(
-            offline_files_path + genome + ".tar.gz",
-            ref_dir + "/references/chromosomes/tsb/",
+            offline_files_path + genome + ".tar.gz", str(reference_dir.get_tsb_dir())
         )
         os.chdir(cur_dir)
 
-        chromosome_fasta_path = ref_dir + "/references/chromosomes/tsb/"
-        chromosome_TSB_path = chromosome_fasta_path + genome + "/"
+        chromosome_fasta_path = reference_dir.get_tsb_dir()
+        chromosome_TSB_path = str(reference_dir.get_tsb_dir() / genome) + "/"
         corrupt = False
 
         for files in os.listdir(chromosome_TSB_path):
@@ -995,11 +987,11 @@ def install(
         if os.path.exists("install.log"):
             os.remove("install.log")
 
-        install_chromosomes(genomes, ref_dir, custom, rsync, bash)
-        install_chromosomes_tsb(genomes, ref_dir, custom)
+        install_chromosomes(genomes, reference_dir, custom, rsync, bash)
+        install_chromosomes_tsb(genomes, reference_dir, custom)
 
         if custom:
-            install_chromosomes_tsb_BED(genomes, ref_dir, custom)
+            install_chromosomes_tsb_BED(genomes, reference_dir, custom)
 
     if os.path.exists("BRCA_example/"):
         shutil.copy("BRCA_example/", "references/vcf_files/")

--- a/SigProfilerMatrixGenerator/scripts/SigProfilerMatrixGenerator.py
+++ b/SigProfilerMatrixGenerator/scripts/SigProfilerMatrixGenerator.py
@@ -97,7 +97,7 @@ def reference_paths(genome):
     """
     reference_dir = ref_install.reference_dir()
     ref_dir = str(reference_dir.path)
-    chrom_path = ref_dir + "/references/chromosomes/tsb/" + genome + "/"
+    chrom_path = str(reference_dir.get_tsb_dir() / genome) + "/"
 
     return (chrom_path, ref_dir)
 

--- a/SigProfilerMatrixGenerator/scripts/SigProfilerMatrixGeneratorFunc.py
+++ b/SigProfilerMatrixGenerator/scripts/SigProfilerMatrixGeneratorFunc.py
@@ -101,8 +101,8 @@ def SigProfilerMatrixGeneratorFunc(
     reference_dir = ref_install.reference_dir()
     lib_loc = str(reference_dir.path)
 
-    tsb_path = os.path.join("references/chromosomes/tsb/", reference_genome)
-    if not os.path.exists(os.path.join(lib_loc, tsb_path)):
+    absolute_tsb_path = str(reference_dir.get_tsb_dir() / reference_genome)
+    if not os.path.exists(absolute_tsb_path):
         raise Exception(
             "The specified genome "
             + reference_genome
@@ -119,7 +119,7 @@ def SigProfilerMatrixGeneratorFunc(
     if reference_genome in list(install.check_sum.keys()):
         for chrom_file_name in check_files:
             chrom_path = os.path.join(
-                lib_loc, tsb_path, chrom_file_name.replace("_transcripts", "")
+                absolute_tsb_path, chrom_file_name.replace("_transcripts", "")
             )
             chrom_val = chrom_file_name.strip("_transcripts.txt")
             chrom_md5 = install.md5(chrom_path)
@@ -1199,7 +1199,7 @@ def SigProfilerMatrixGeneratorFunc(
     # Organizes all of the reference directories for later reference:
     reference_dir = ref_install.reference_dir()
     ref_dir = str(reference_dir.path)
-    chrom_path = ref_dir + "/references/chromosomes/tsb/" + reference_genome + "/"
+    chrom_path = str(reference_dir.get_tsb_dir() / reference_genome) + "/"
     if "havana" in reference_genome:
         reference_genome = reference_genome.split("_")[0]
     transcript_path = (

--- a/SigProfilerMatrixGenerator/scripts/ref_install.py
+++ b/SigProfilerMatrixGenerator/scripts/ref_install.py
@@ -8,26 +8,55 @@ import pkg_resources
 import SigProfilerMatrixGenerator
 
 
-def reference_dir(path: Optional[Union[str, pathlib.Path]] = None) -> "ReferenceDir":
+def reference_dir(
+    secondary_chromosome_install_dir: Optional[Union[str, pathlib.Path]] = None
+) -> "ReferenceDir":
     """Small constructor for ReferenceDir"""
-    if path is None:
-        try:
-            # python >= 3.9
-            path = resources.files(SigProfilerMatrixGenerator)
-        except AttributeError:
-            # python 3.8, deprecated
-            path = pathlib.Path(
-                pkg_resources.resource_filename(SigProfilerMatrixGenerator.__name__, "")
-            )
-    return ReferenceDir(pathlib.Path(path))
+    if secondary_chromosome_install_dir is not None:
+        install_dir = pathlib.Path(secondary_chromosome_install_dir)
+    else:
+        install_dir = None
+    result = ReferenceDir(secondary_chromosome_install_dir=install_dir)
+    return result
 
 
 class ReferenceDir:
     """The directory where the reference genomes are installed"""
 
-    def __init__(self, path: pathlib.Path):
-        self._path = path
+    _default_chromosome_dir = pathlib.Path("references", "chromosomes")
+
+    def __init__(self, secondary_chromosome_install_dir: Optional[pathlib.Path] = None):
+        self._secondary_chromosome_install_dir = secondary_chromosome_install_dir
 
     @property
     def path(self) -> pathlib.Path:
-        return self._path.resolve()
+        """Where references that cannot be installed are"""
+        root_path = self._get_package_installation_folder()
+        return root_path.resolve()
+
+    def get_fasta_dir(self) -> pathlib.Path:
+        result = self.get_chromosomes_dir() / "fasta"
+        return result
+
+    def get_tsb_dir(self) -> pathlib.Path:
+        result = self.get_chromosomes_dir() / "tsb"
+        return result
+
+    def get_chromosomes_dir(self) -> pathlib.Path:
+        if self._secondary_chromosome_install_dir is None:
+            root_dir = self.path / self._default_chromosome_dir
+        else:
+            root_dir = self._secondary_chromosome_install_dir.resolve()
+        result = root_dir
+        return result
+
+    def _get_package_installation_folder(self):
+        try:
+            # python >= 3.9
+            result = resources.files(SigProfilerMatrixGenerator)
+        except AttributeError:
+            # python 3.8, deprecated
+            result = pathlib.Path(
+                pkg_resources.resource_filename(SigProfilerMatrixGenerator.__name__, "")
+            )
+        return result

--- a/SigProfilerMatrixGenerator/scripts/save_chrom_strings.py
+++ b/SigProfilerMatrixGenerator/scripts/save_chrom_strings.py
@@ -34,7 +34,7 @@ def save_chrom_strings(genome, custom=False):
 
     reference_dir = ref_install.reference_dir()
     ref_dir = str(reference_dir.path)
-    chrom_fasta_path = ref_dir + "/references/chromosomes/fasta/" + genome + "/"
+    chrom_fasta_path = str(reference_dir.get_fasta_root_dir()) + genome + "/"
     chrom_string_path = ref_dir + "/references/chromosomes/chrom_string/" + genome + "/"
     chrom_fasta_files = os.listdir(chrom_fasta_path)
     if not os.path.exists(chrom_string_path):

--- a/SigProfilerMatrixGenerator/scripts/save_chrom_tsb_separate.py
+++ b/SigProfilerMatrixGenerator/scripts/save_chrom_tsb_separate.py
@@ -11,15 +11,17 @@ import os
 import pickle
 import re
 
+from SigProfilerMatrixGenerator.scripts import ref_install
 
-def save_chrom_tsb_separate(genome, ref_dir, custom):
+
+def save_chrom_tsb_separate(genome, reference_dir: ref_install.ReferenceDir, custom):
     """
     Saves the transcriptional strand bias information for a given genome
     into a BED file.
 
     Parameters:
-             genome  -> reference genome
-            ref_dir  -> directory from which the parent script is being called.
+            genome  -> reference genome
+            reference_dir  -> ReferenceDir object from which the parent script is being called.
 
     Returns:
               None
@@ -27,9 +29,11 @@ def save_chrom_tsb_separate(genome, ref_dir, custom):
     Outputs:
             BED files that contain the TSB information and their associated ranges.
     """
+    ref_dir = reference_dir.path
 
     # Instantiates all of the relevant path and reference varibales
-    chromosome_path = ref_dir + "/references/chromosomes/tsb/" + genome + "/"
+    chromosome_path = str(reference_dir.get_tsb_dir()) + genome + "/"
+
     chromosome_BED_path = ref_dir + "/references/chromosomes/tsb_BED/" + genome + "/"
     chromosomes = [
         "X",

--- a/SigProfilerMatrixGenerator/scripts/save_context_distribution.py
+++ b/SigProfilerMatrixGenerator/scripts/save_context_distribution.py
@@ -13,6 +13,8 @@ import os
 import re
 import sys
 
+from SigProfilerMatrixGenerator.scripts import ref_install
+
 revcompl = lambda x: "".join(
     [{"A": "T", "C": "G", "G": "C", "T": "A", "N": "N"}[B] for B in x][::-1]
 )
@@ -328,10 +330,8 @@ def context_distribution_BED(
     first_line = True
     chrom_length = 0
     if exome:
-        # file_to_open = ref_dir + "/references/chromosomes/exome/" + genome + "/" + exome_file
         file_to_open = exome_file
     else:
-        # file_to_open = ref_dir + "/references/vcf_files/BED/" + bed_file
         file_to_open = bed_file
 
     chromosomes_sort = chromosomes
@@ -675,10 +675,9 @@ def main():
         chromosomes = chromosomes[:22]
 
     script_dir = os.getcwd()
-    ref_dir = re.sub("\/scripts$", "", script_dir)
-    # chromosome_path = ref_dir + "/references/chromosomes/chrom_string/" + genome + "/"
-    # chromosome_path = "/Users/ebergstr/Desktop/test_bi/references/chromosomes/tsb/GRCh37/"
-    chromosome_path = ref_dir + "/references/chromosomes/tsb/" + genome + "/"
+    reference_dir = ref_install.reference_dir()
+    ref_dir = reference_dir.path
+    chromosome_path = str(reference_dir.get_tsb_dir() / genome) + "/"
 
     output_path = ref_dir + "/references/chromosomes/context_distributions/"
     if not os.path.exists(output_path):

--- a/tests/scripts/test_ref_install.py
+++ b/tests/scripts/test_ref_install.py
@@ -1,35 +1,75 @@
 import pathlib
 
 import pkg_resources
+import pytest
 
 import SigProfilerMatrixGenerator
 from SigProfilerMatrixGenerator.scripts import ref_install
 
 
 class TestReferenceDir:
-    def test_reference_dir_default(self):
-        refdir = ref_install.reference_dir(None)
-        # using deprecated pkg_resources for compatibility with python 3.8
-        expected = pathlib.Path(
+    @pytest.fixture
+    def package_reference_dir(self):
+        result = pathlib.Path(
             pkg_resources.resource_filename(SigProfilerMatrixGenerator.__name__, "")
         )
+        return result
+
+    @pytest.fixture
+    def default_fasta_dir(self, package_reference_dir):
+        result = package_reference_dir / "references" / "chromosomes" / "fasta"
+        return result
+
+    @pytest.fixture
+    def default_tsb_dir(self, package_reference_dir):
+        result = package_reference_dir / "references" / "chromosomes" / "tsb"
+        return result
+
+    def test_path_no_secondary_chromosome_install_dir(self, package_reference_dir):
+        refdir = ref_install.reference_dir()
+        # using deprecated pkg_resources for compatibility with python 3.8
         observed = refdir.path
-        assert expected == observed
+        assert package_reference_dir == observed
         # check path is absolute
         assert observed == observed.resolve()
 
-    def test_reference_dir_custom(self):
-        paths = ["/somewhere", pathlib.Path("/somewhere")]
-        for provided in paths:
-            expected = pathlib.Path("/somewhere")
-            refdir = ref_install.reference_dir(provided)
-            observed = refdir.path
-            assert expected == observed
-
-    def test_path_relative(self):
-        provided = pathlib.Path("relative/to/here")
-        expected = pathlib.Path.cwd() / "relative/to/here"
-
-        refdir = ref_install.ReferenceDir(provided)
+    def test_path_not_affected_by_secondary_chromosome_install_dir(
+        self, package_reference_dir
+    ):
+        refdir = ref_install.reference_dir(
+            secondary_chromosome_install_dir="/somewhere"
+        )
         observed = refdir.path
-        assert expected == observed
+        assert observed == package_reference_dir
+
+    def test_get_fasta_dir_default(self, default_fasta_dir):
+        refdir = ref_install.reference_dir()
+        observed = refdir.get_fasta_dir()
+        assert observed == default_fasta_dir
+
+    get_fasta_dir_data = [
+        pytest.param(
+            "/somewhere", pathlib.Path("/somewhere/fasta"), id="absolute,string"
+        ),
+        pytest.param(
+            "relative/to/here",
+            pathlib.Path.cwd() / "relative/to/here/fasta",
+            id="relative,string",
+        ),
+        pytest.param(
+            pathlib.Path("relative/to/here"),
+            pathlib.Path.cwd() / "relative/to/here/fasta",
+            id="relative,path",
+        ),
+    ]
+
+    @pytest.mark.parametrize("provided,expected", get_fasta_dir_data)
+    def test_get_fasta_dir(self, provided, expected):
+        refdir = ref_install.reference_dir(secondary_chromosome_install_dir=provided)
+        observed = refdir.get_fasta_dir()
+        assert observed == expected
+
+    def test_get_tsb_dir_default(self, default_tsb_dir):
+        refdir = ref_install.reference_dir()
+        observed = refdir.get_tsb_dir()
+        assert observed == default_tsb_dir


### PR DESCRIPTION
- Add internal knowledge to the ReferenceDir object about fasta and tsb folders relative to either the package root or the secondary installation folder if provided
- Update the code that set the fasta or tsb folder to use the new object