### PR TITLE
fix #133: update DataFrame append to concat

### DIFF
--- a/SigProfilerMatrixGenerator/scripts/MutationMatrixGenerator.py
+++ b/SigProfilerMatrixGenerator/scripts/MutationMatrixGenerator.py
@@ -2941,11 +2941,11 @@ def matrix_generator(
     nontrans = mut_count_all["6144"][mut_count_all["6144"].index.str.contains("N:")]
     a = bitrans // 2
     b = bitrans % 2
-    trans = trans.append(a)
-    trans = trans.append(b)
+    trans = pd.concat([trans, a])
+    trans = pd.concat([trans, b])
     trans = trans.groupby(trans.index.str[2:]).sum()
     trans = trans.rename(index=lambda s: "T:" + s)
-    untrans = untrans.append(a)
+    untrans = pd.concat([untrans, a])
     untrans = untrans.groupby(untrans.index.str[2:]).sum()
     untrans = untrans.rename(index=lambda s: "U:" + s)
     mut_count_all["4608"] = pd.concat([trans, untrans, nontrans])
@@ -2960,11 +2960,11 @@ def matrix_generator(
     nontrans = mut_count_all["384"][mut_count_all["384"].index.str.contains("N:")]
     a = bitrans // 2
     b = bitrans % 2
-    trans = trans.append(a)
-    trans = trans.append(b)
+    trans = pd.concat([trans, a])
+    trans = pd.concat([trans, b])
     trans = trans.groupby(trans.index.str[2:]).sum()
     trans = trans.rename(index=lambda s: "T:" + s)
-    untrans = untrans.append(a)
+    untrans = pd.concat([untrans, a])
     untrans = untrans.groupby(untrans.index.str[2:]).sum()
     untrans = untrans.rename(index=lambda s: "U:" + s)
     mut_count_all["288"] = pd.concat([trans, untrans, nontrans])
@@ -2976,11 +2976,11 @@ def matrix_generator(
     nontrans = mut_count_all["24"][mut_count_all["24"].index.str.contains("N:")]
     a = bitrans // 2
     b = bitrans % 2
-    trans = trans.append(a)
-    trans = trans.append(b)
+    trans = pd.concat([trans, a])
+    trans = pd.concat([trans, b])
     trans = trans.groupby(trans.index.str[2:]).sum()
     trans = trans.rename(index=lambda s: "T:" + s)
-    untrans = untrans.append(a)
+    untrans = pd.concat([untrans, a])
     untrans = untrans.groupby(untrans.index.str[2:]).sum()
     untrans = untrans.rename(index=lambda s: "U:" + s)
     mut_count_all["18"] = pd.concat([trans, untrans, nontrans])
@@ -3572,11 +3572,11 @@ def matrix_generator_INDEL(
         questionable = indel_tsb_dict[indel_tsb_dict.index.str.contains("Q:")]
         a = bitrans // 2
         b = bitrans % 2
-        trans = trans.append(a)
-        trans = trans.append(b)
+        trans = pd.concat([trans, a])
+        trans = pd.concat([trans, b])
         trans = trans.groupby(trans.index.str[2:]).sum()
         trans = trans.rename(index=lambda s: "T:" + s)
-        untrans = untrans.append(a)
+        untrans = pd.concat([untrans, a])
         untrans = untrans.groupby(untrans.index.str[2:]).sum()
         untrans = untrans.rename(index=lambda s: "U:" + s)
         indel_tsb_dict_abbrev = pd.concat([trans, untrans, nontrans, questionable])
@@ -3787,11 +3787,11 @@ def matrix_generator_DINUC(
     questionable = mut_count_all["186"][mut_count_all["186"].index.str.contains("Q:")]
     a = bitrans // 2
     b = bitrans % 2
-    trans = trans.append(a)
-    trans = trans.append(b)
+    trans = pd.concat([trans, a])
+    trans = pd.concat([trans, b])
     trans = trans.groupby(trans.index.str[2:]).sum()
     trans = trans.rename(index=lambda s: "T:" + s)
-    untrans = untrans.append(a)
+    untrans = pd.concat([untrans, a])
     untrans = untrans.groupby(untrans.index.str[2:]).sum()
     untrans = untrans.rename(index=lambda s: "U:" + s)
     mut_count_all["150"] = pd.concat([trans, untrans, nontrans, questionable])
@@ -3804,11 +3804,11 @@ def matrix_generator_DINUC(
     questionable = mut_4992[mut_4992.index.str.contains("Q:")]
     a = bitrans // 2
     b = bitrans % 2
-    trans = trans.append(a)
-    trans = trans.append(b)
+    trans = pd.concat([trans, a])
+    trans = pd.concat([trans, b])
     trans = trans.groupby(trans.index.str[2:]).sum()
     trans = trans.rename(index=lambda s: "T:" + s)
-    untrans = untrans.append(a)
+    untrans = pd.concat([untrans, a])
     untrans = untrans.groupby(untrans.index.str[2:]).sum()
     untrans = untrans.rename(index=lambda s: "U:" + s)
     mut_count_all["2400"] = pd.concat([trans, untrans, nontrans, questionable])


### PR DESCRIPTION
Previously `trans` and `untrans` have been appending another DataFrame, either `a` or `b`. 
Fixed #133 by applying a simple fix: using `concat` instead of `append`.